### PR TITLE
Relation between JSX and JS.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,12 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Document</title>
 </head>
+
 <body>
-  <p>This is the index.html file</p>
+  <div id='app'></div>
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+  <script src='/scripts/app.js'></script>
 </body>
+
 </html>

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -1,0 +1,10 @@
+console.log('App.js is running')
+
+// JSX 
+// var template = <p id='someid'>This is JSX from App.js</p> 
+// The line above is JSX. The browser does not understand JSX. Using Babeljs.io, JSX was compiled to vanilla JS.
+var template = React.createElement("h1", {
+  id: "someid"
+}, "This is JSX from App.js");
+var appRoot = document.getElementById('app')
+ReactDOM.render(template, appRoot)


### PR DESCRIPTION
Using Babeljs.io, JSX is compiled to vanilla JS. The browser does not understand JSX.
The browser only understand JS.